### PR TITLE
Cambio consulta SQL de DSpace6 y DSpace7 para comparar por uuid y no texto y mejorar rendimiento

### DIFF
--- a/dspace_stats_collector/dspacedb6.py
+++ b/dspace_stats_collector/dspacedb6.py
@@ -34,7 +34,7 @@ class DSpaceDB6(DSpaceDB):
                 AND b.sequence_id IS NOT NULL
                 AND b.deleted = FALSE
                 AND mv2.metadata_field_id = {dcTitleId}
-                AND mv.dspace_object_id::text = '{bitstreamId}';
+                AND mv.dspace_object_id = uuid('{bitstreamId}');
         """
 
         self._queryItemSQL = """
@@ -49,7 +49,7 @@ class DSpaceDB6(DSpaceDB):
             RIGHT JOIN handle AS h ON h.resource_id = mv.dspace_object_id
             WHERE metadata_field_id = {dcTitleId}
                 AND h.resource_type_id=2
-                AND mv.dspace_object_id::text = '{itemId}';
+                AND mv.dspace_object_id = uuid('{itemId}');
         """
       
         self._queryTitleSQL = """

--- a/dspace_stats_collector/dspacedb7.py
+++ b/dspace_stats_collector/dspacedb7.py
@@ -34,7 +34,7 @@ class DSpaceDB7(DSpaceDB):
                 AND b.sequence_id IS NOT NULL
                 AND b.deleted = FALSE
                 AND mv2.metadata_field_id = {dcTitleId}
-                AND mv.dspace_object_id::text = '{bitstreamId}';
+                AND mv.dspace_object_id = uuid('{bitstreamId}');
         """
 
         self._queryItemSQL = """
@@ -49,7 +49,7 @@ class DSpaceDB7(DSpaceDB):
             RIGHT JOIN handle AS h ON h.resource_id = mv.dspace_object_id
             WHERE metadata_field_id = {dcTitleId}
                 AND h.resource_type_id=2
-                AND mv.dspace_object_id::text = '{itemId}';
+                AND mv.dspace_object_id = uuid('{itemId}');
         """
       
         self._queryTitleSQL = """


### PR DESCRIPTION
Modificación de las consultas SQL para la versión 6 i 7 de DSpace con postgres para que utilize el indice para comprobar la condición dspace_object_id sea igual al uuid buscado.

Mejora mucho el rendimiento, una consulta puede pasar de 16 segundos a mili-segundos.

Probado para la versión 6 pero también se debería aplicar a la 7 ya que esta parte es común.